### PR TITLE
Hubot will HELP you only if you ask nicely

### DIFF
--- a/src/help.coffee
+++ b/src/help.coffee
@@ -66,6 +66,17 @@ module.exports = (robot) ->
 
     emit = cmds.join "\n"
 
+    if (msg.envelope.room is not
+        msg.envelope.user.name and
+        cmds.length > 20)
+      response = "Woah there, there are a lot of help commands." +
+      " Can you be more specific by trying '" + robot.name +
+      " help <topic>' instead? Or if you want all the help commands," +
+      " try direct messaging me @" + robot.name
+
+      msg.send response
+      return
+
     msg.send emit
 
   robot.router.get "/#{robot.name}/help", (req, res) ->

--- a/src/help.coffee
+++ b/src/help.coffee
@@ -64,9 +64,7 @@ module.exports = (robot) ->
         msg.send "No available commands match #{filter}"
         return
 
-    emit = cmds.join "\n"
-
-    if (msg.envelope.room is not
+    else if (msg.envelope.room is not
         msg.envelope.user.name and
         cmds.length > 20)
       response = "Woah there, there are a lot of help commands." +
@@ -76,6 +74,8 @@ module.exports = (robot) ->
 
       msg.send response
       return
+
+    emit = cmds.join "\n"
 
     msg.send emit
 


### PR DESCRIPTION
I wanted to stop the ability for users to flood the channels with every command that hubot is capable of when doing the blanket `hubot help` command and instead direct them to direct message the bot one-on-one. If they decide to do a `hubot help time` for example - which is a filtered help, then they will get those help messages.

This isn't a direct solution for all possible chatting mediums that hubot is capable of (e.g. IRC, Hipchat, Slack, etc...) but it will serve our own purposes, that is until the main `hubot-scripts/hubot-help` repository resolves the issue there.
